### PR TITLE
Potential fix for code scanning alert no. 2: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/pkg/binaries/downloader.go
+++ b/pkg/binaries/downloader.go
@@ -140,16 +140,27 @@ func (d *BinaryDownloader) downloadAndExtractBinaries(version, destDir string) e
 			continue
 		}
 
+		// Check for directory traversal
+		if strings.Contains(header.Name, "..") {
+			return fmt.Errorf("invalid file path in tar: %s", header.Name)
+		}
+
 		// Get the target path
 		targetPath := filepath.Join(destDir, header.Name)
+		cleanTargetPath := filepath.Clean(targetPath)
+
+		// Ensure the target path is within the destination directory
+		if !strings.HasPrefix(cleanTargetPath, filepath.Clean(destDir)+string(os.PathSeparator)) {
+			return fmt.Errorf("invalid file path in tar: %s", header.Name)
+		}
 
 		// Create directory structure
-		if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(cleanTargetPath), 0755); err != nil {
 			return fmt.Errorf("failed to create directory structure: %w", err)
 		}
 
 		// Create file
-		f, err := os.OpenFile(targetPath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+		f, err := os.OpenFile(cleanTargetPath, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 		if err != nil {
 			return fmt.Errorf("failed to create file: %w", err)
 		}
@@ -163,7 +174,7 @@ func (d *BinaryDownloader) downloadAndExtractBinaries(version, destDir string) e
 
 		// Make binary executable if in bin directory
 		if strings.HasPrefix(header.Name, "bin/") {
-			if err := os.Chmod(targetPath, 0755); err != nil {
+			if err := os.Chmod(cleanTargetPath, 0755); err != nil {
 				return fmt.Errorf("failed to make binary executable: %w", err)
 			}
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/LF-Decentralized-Trust-labs/chaindeploy/security/code-scanning/2](https://github.com/LF-Decentralized-Trust-labs/chaindeploy/security/code-scanning/2)

To fix the problem, we need to ensure that the `header.Name` does not contain any directory traversal sequences like `..` before using it to construct file paths. This can be done by checking if the `header.Name` contains `..` and skipping such entries if they do. Additionally, we should ensure that the target path is within the intended destination directory.

1. Add a check to ensure `header.Name` does not contain `..`.
2. Ensure the target path is within the intended destination directory by using `filepath.Clean` and comparing the resulting path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
