### PR TITLE
fix(nodes): propagate external endpoint changes on peer/orderer edit

### DIFF
--- a/pkg/db/migrations/0024_add_verification_failed_network_status.down.sql
+++ b/pkg/db/migrations/0024_add_verification_failed_network_status.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM node_statuses WHERE name = 'verification_failed';

--- a/pkg/db/migrations/0024_add_verification_failed_network_status.up.sql
+++ b/pkg/db/migrations/0024_add_verification_failed_network_status.up.sql
@@ -1,0 +1,5 @@
+-- Add the 'verification_failed' status used by the FabricX network
+-- post-provisioning verification step. The networks table reuses the
+-- node_statuses lookup table for its status FK, so the value has to be
+-- registered there before any UPDATE can reference it.
+INSERT OR IGNORE INTO node_statuses (name) VALUES ('verification_failed');

--- a/pkg/networks/http/fabricx_handler.go
+++ b/pkg/networks/http/fabricx_handler.go
@@ -283,6 +283,36 @@ func (h *Handler) FabricXNetworkJoinNode(w http.ResponseWriter, r *http.Request)
 	})
 }
 
+// FabricXVerifyResponse is the body returned by the verification endpoint.
+type FabricXVerifyResponse struct {
+	NetworkID int64  `json:"networkId"`
+	Status    string `json:"status"` // "running" on success, "verification_failed" on error
+}
+
+// FabricXNetworkVerify godoc
+// @Summary Verify a FabricX network end-to-end
+// @Description Runs the post-provisioning smoke test for the network: dials the orderer router with TLS and creates a permanent healthcheck namespace named __chainlaunch_healthcheck__. On success the network is flipped to "running"; on failure to "verification_failed" with the reason in server logs. Idempotent — if the healthcheck namespace already exists, the network is marked running without sending a new transaction.
+// @Tags FabricX Networks
+// @Param id path int true "Network ID"
+// @Success 200 {object} FabricXVerifyResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /networks/fabricx/{id}/verify [post]
+func (h *Handler) FabricXNetworkVerify(w http.ResponseWriter, r *http.Request) {
+	networkID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_network_id", "Invalid network ID")
+		return
+	}
+	if err := h.networkService.VerifyFabricXNetwork(r.Context(), networkID); err != nil {
+		writeError(w, http.StatusInternalServerError, "network_verification_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, FabricXVerifyResponse{
+		NetworkID: networkID,
+		Status:    "running",
+	})
+}
+
 func mapFabricXNetworkToResponse(n service.Network) FabricXNetworkResponse {
 	var channelName string
 	if n.Config != nil {

--- a/pkg/networks/http/handler.go
+++ b/pkg/networks/http/handler.go
@@ -86,6 +86,7 @@ func (h *Handler) RegisterRoutes(r chi.Router) {
 		r.Delete("/{id}", h.FabricXNetworkDelete)
 		r.Get("/{id}/nodes", h.FabricXNetworkGetNodes)
 		r.Post("/{id}/nodes/{nodeId}/join", h.FabricXNetworkJoinNode)
+		r.Post("/{id}/verify", h.FabricXNetworkVerify)
 
 		r.Get("/{id}/namespaces", h.FabricXNamespaceList)
 		r.Post("/{id}/namespaces", h.FabricXNamespaceCreate)

--- a/pkg/networks/service/fabricx.go
+++ b/pkg/networks/service/fabricx.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"time"
 
 	"github.com/chainlaunch/chainlaunch/pkg/db"
 	"github.com/chainlaunch/chainlaunch/pkg/networks/service/fabricx"
@@ -47,7 +48,56 @@ func (s *NetworkService) JoinFabricXNodeToNetwork(ctx context.Context, networkID
 	if err := deployer.JoinNode(networkID, genesisBlock, nodeID); err != nil {
 		return fmt.Errorf("failed to join FabricX node %d to network %d: %w", nodeID, networkID, err)
 	}
+
+	// Once every network_node row for this network is in the "joined"
+	// state, kick off the verification smoke test. This is best-effort —
+	// the join itself is what the caller is waiting for; verification
+	// updates the network status asynchronously and surfaces errors via
+	// the structured logs (and via /networks/{id} status).
+	if allJoined, err := s.allFabricXNodesJoined(ctx, networkID); err == nil && allJoined {
+		go func() {
+			verifyCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+			if vErr := s.deployerFactory.GetFabricXDeployer().VerifyNetwork(verifyCtx, networkID); vErr != nil {
+				// Already logged inside VerifyNetwork; nothing to do
+				// here besides not propagating to the join caller.
+				_ = vErr
+			}
+		}()
+	}
 	return nil
+}
+
+// allFabricXNodesJoined returns true if every network_node row for the
+// given network is in a state that means the underlying node has the
+// genesis block on disk. We treat anything other than the literal
+// "pending" status as "joined" — the JoinNode path flips rows to
+// "joined" before container start, and a transient docker-mount error
+// during start does not invalidate that.
+func (s *NetworkService) allFabricXNodesJoined(ctx context.Context, networkID int64) (bool, error) {
+	rows, err := s.db.GetNetworkNodes(ctx, networkID)
+	if err != nil {
+		return false, err
+	}
+	if len(rows) == 0 {
+		return false, nil
+	}
+	for _, r := range rows {
+		if r.Status == "pending" {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// VerifyFabricXNetwork is the operator-facing entry point for the
+// post-provisioning smoke test. It is also called automatically by
+// JoinFabricXNodeToNetwork once every node has joined; the explicit
+// endpoint exists so the operator can re-run verification after fixing
+// a problem (e.g. a flaky orderer) without having to recreate any
+// nodes.
+func (s *NetworkService) VerifyFabricXNetwork(ctx context.Context, networkID int64) error {
+	return s.deployerFactory.GetFabricXDeployer().VerifyNetwork(ctx, networkID)
 }
 
 // CreateFabricXNamespace broadcasts a namespace-creation tx to the network's

--- a/pkg/networks/service/fabricx/deployer.go
+++ b/pkg/networks/service/fabricx/deployer.go
@@ -1,10 +1,12 @@
 package fabricx
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/chainlaunch/chainlaunch/pkg/config"
@@ -101,6 +103,7 @@ func (d *FabricXDeployer) CreateGenesisBlock(networkID int64, config interface{}
 			deploymentCfg nodetypes.FabricXOrdererGroupDeploymentConfig
 			sourceUpdated any
 			sourceCreated any
+			sourceName    string
 		)
 		if orgRef.OrdererNodeGroupID != 0 {
 			grp, err := d.db.GetNodeGroup(ctx, orgRef.OrdererNodeGroupID)
@@ -115,6 +118,7 @@ func (d *FabricXDeployer) CreateGenesisBlock(networkID int64, config interface{}
 			}
 			sourceUpdated = grp.UpdatedAt
 			sourceCreated = grp.CreatedAt
+			sourceName = grp.Name
 		} else {
 			dbNode, err := d.db.GetNode(ctx, orgRef.OrdererNodeID)
 			if err != nil {
@@ -128,6 +132,7 @@ func (d *FabricXDeployer) CreateGenesisBlock(networkID int64, config interface{}
 			}
 			sourceUpdated = dbNode.UpdatedAt
 			sourceCreated = dbNode.CreatedAt
+			sourceName = dbNode.Name
 		}
 
 		externalHost := deploymentCfg.ExternalIP
@@ -156,6 +161,17 @@ func (d *FabricXDeployer) CreateGenesisBlock(networkID int64, config interface{}
 			"source.updatedAt", sourceUpdated,
 			"source.createdAt", sourceCreated,
 		)
+
+		// Cert drift guard: refuse to embed a TLS cert in genesis that
+		// doesn't match what's actually on disk for this orderer group.
+		// If we let drift slip into genesis, the router will panic at
+		// startup with "certificate mismatch" and the network is
+		// unrecoverable (genesis is immutable). The fix is to make the
+		// caller stop regenerating certs out-of-band — typically that
+		// means re-running Init(), which is now idempotent.
+		if err := d.assertOrdererCertMatchesDisk(sourceName, deploymentCfg); err != nil {
+			return nil, fmt.Errorf("orderer cert drift before genesis (party %d, msp %s): %w", partyID, deploymentCfg.MSPID, err)
+		}
 
 		genesisParties = append(genesisParties, fabricxpkg.GenesisParty{
 			PartyID:   partyID,
@@ -244,6 +260,57 @@ func (d *FabricXDeployer) CreateGenesisBlock(networkID int64, config interface{}
 	return genesisBlock, nil
 }
 
+// assertOrdererCertMatchesDisk fails fast when the TLS cert recorded in
+// the orderer group's deployment_config differs from the cert currently
+// on disk for any of its four roles. If we let a mismatch slip into the
+// genesis block, the orderer router crashes at startup ("certificate
+// mismatch") and the network is unrecoverable because genesis is
+// immutable.
+//
+// We compare each role's server.crt against deploymentCfg.TLSCert. The
+// cert is shared across all four roles, so any one of them disagreeing
+// with the DB is enough to abort. We trim trailing whitespace before
+// comparison because writeTLS leaves a trailing newline that os.WriteFile
+// preserves verbatim.
+func (d *FabricXDeployer) assertOrdererCertMatchesDisk(groupName string, cfg nodetypes.FabricXOrdererGroupDeploymentConfig) error {
+	if d.configService == nil {
+		// In tests where configService is not wired we can't resolve
+		// the data path; skip the check. Production always has it.
+		return nil
+	}
+	dbCert := bytes.TrimSpace([]byte(cfg.TLSCert))
+	if len(dbCert) == 0 {
+		return fmt.Errorf("deployment config TLS cert is empty")
+	}
+	if groupName == "" {
+		return fmt.Errorf("orderer group name is empty; cannot resolve on-disk cert path")
+	}
+	dataPath := d.configService.GetDataPath()
+	for _, role := range []string{"router", "batcher", "consenter", "assembler"} {
+		path := fabricxpkg.OrdererRoleTLSCertPath(dataPath, groupName, role)
+		onDisk, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Disk wasn't laid out yet — Init() must run before
+				// genesis. Surface a clear error so the operator
+				// knows to (re)create the orderer node first.
+				return fmt.Errorf("orderer %s cert not found on disk at %s; was Init() run?", role, path)
+			}
+			return fmt.Errorf("read %s cert at %s: %w", role, path, err)
+		}
+		if !bytes.Equal(bytes.TrimSpace(onDisk), dbCert) {
+			return fmt.Errorf(
+				"role %s cert on disk differs from deployment config (disk=%s, db=%s); "+
+					"this means a regenerate ran after init — refusing to bake the stale cert into genesis",
+				role,
+				fabricxpkg.CertFingerprint(onDisk),
+				fabricxpkg.CertFingerprint(dbCert),
+			)
+		}
+	}
+	return nil
+}
+
 // JoinNode sets the genesis block on a Fabric X node and updates its network status.
 func (d *FabricXDeployer) JoinNode(networkID int64, genesisBlock []byte, nodeID int64) error {
 	ctx := context.Background()
@@ -322,6 +389,136 @@ func isTransientDockerMountErr(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "bind source path does not exist") ||
 		(strings.Contains(msg, "invalid mount config for type \"bind\"") && strings.Contains(msg, "operation not permitted"))
+}
+
+// HealthcheckNamespaceName is the name of the persistent namespace the
+// deployer creates after every node has joined the network. Its presence
+// proves three things end-to-end: the orderer router accepts TLS
+// connections, the consensus path commits a transaction, and the
+// committer-sidecar replays the block to its query-service. Operators
+// can list it via the namespace API; it is intentionally NOT deleted
+// after verification because re-running verification is cheap and the
+// row is auditable.
+const HealthcheckNamespaceName = "__chainlaunch_healthcheck__"
+
+// VerifyNetwork runs the post-provisioning smoke test for a FabricX
+// network. It blocks until either:
+//   - The healthcheck namespace exists on-chain (success → returns nil)
+//   - The deadline elapses or a non-retriable error fires (failure)
+//
+// On success VerifyNetwork transitions the network to "running"; on
+// failure it sets "verification_failed" and stores the underlying error
+// in the network's error_message column so the UI can show *why* a
+// "provisioned" network is actually broken.
+//
+// The submitter is auto-picked: the first organization in the network's
+// config whose admin sign key is present in the local DB. We don't
+// expose this choice to the API caller because verification is a
+// system-driven step, not a user transaction.
+//
+// VerifyNetwork is idempotent: if the healthcheck namespace already
+// exists on-chain, it returns success immediately without sending a new
+// transaction.
+func (d *FabricXDeployer) VerifyNetwork(ctx context.Context, networkID int64) error {
+	network, err := d.db.GetNetwork(ctx, networkID)
+	if err != nil {
+		return fmt.Errorf("get network %d: %w", networkID, err)
+	}
+	if !network.Config.Valid {
+		return fmt.Errorf("network %d has no config", networkID)
+	}
+	var cfg types.FabricXNetworkConfig
+	if err := json.Unmarshal([]byte(network.Config.String), &cfg); err != nil {
+		return fmt.Errorf("parse network config: %w", err)
+	}
+	if len(cfg.Organizations) == 0 {
+		return fmt.Errorf("network %d has no organizations", networkID)
+	}
+
+	// Pick the first org that has an admin sign key — without one we
+	// can't sign the namespace-create envelope. This matches the
+	// existing CreateNamespace contract.
+	var submitterOrgID int64
+	for _, orgRef := range cfg.Organizations {
+		org, err := d.orgService.GetOrganization(ctx, orgRef.ID)
+		if err != nil {
+			continue
+		}
+		if org.AdminSignKeyID.Valid && org.AdminSignKeyID.Int64 > 0 {
+			submitterOrgID = org.ID
+			break
+		}
+	}
+	if submitterOrgID == 0 {
+		return fmt.Errorf("no organization in network %d has an admin sign key; cannot run verification", networkID)
+	}
+
+	// Idempotency: skip if the healthcheck namespace already exists on
+	// chain. Listing is allowed to fail with a transient chain-unreachable
+	// error; that's exactly the case CreateNamespace below will surface
+	// as the verification failure.
+	if existing, _, _ := d.ListNamespacesMerged(ctx, networkID); existing != nil {
+		for _, ns := range existing {
+			if ns.Name == HealthcheckNamespaceName {
+				d.logger.Info("verification skipped: healthcheck namespace already on chain",
+					"networkID", networkID, "namespace", HealthcheckNamespaceName)
+				if err := d.markNetworkVerified(ctx, networkID); err != nil {
+					return err
+				}
+				return nil
+			}
+		}
+	}
+
+	d.logger.Info("verifying FabricX network by creating healthcheck namespace",
+		"networkID", networkID, "submitterOrgID", submitterOrgID, "namespace", HealthcheckNamespaceName)
+
+	_, err = d.CreateNamespace(ctx, networkID, NamespaceCreateOptions{
+		Name:            HealthcheckNamespaceName,
+		Version:         -1,
+		SubmitterOrgID:  submitterOrgID,
+		WaitForFinality: true,
+		// Use the submitter org's admin pubkey as the endorsement
+		// policy. Writes to the healthcheck namespace are not
+		// expected post-verification, so this stays internal.
+	})
+	if err != nil {
+		// Persist the verification failure status so /networks/{id}
+		// reflects that the network is unhealthy. We log the detailed
+		// reason — the networks table has no error_message column today,
+		// so the operator-facing error surfaces via the API caller's
+		// returned error and the structured logs below.
+		d.logger.Error("FabricX network verification failed",
+			"networkID", networkID, "namespace", HealthcheckNamespaceName, "err", err)
+		if updErr := d.db.UpdateNetworkStatus(ctx, &db.UpdateNetworkStatusParams{
+			ID:     networkID,
+			Status: "verification_failed",
+		}); updErr != nil {
+			d.logger.Warn("failed to persist verification_failed status",
+				"networkID", networkID, "err", updErr)
+		}
+		return fmt.Errorf("network %d verification failed: %w", networkID, err)
+	}
+
+	if err := d.markNetworkVerified(ctx, networkID); err != nil {
+		return err
+	}
+
+	d.logger.Info("FabricX network verified",
+		"networkID", networkID, "namespace", HealthcheckNamespaceName)
+	return nil
+}
+
+// markNetworkVerified flips a network into the "running" state. Called
+// only after the healthcheck namespace is confirmed on-chain.
+func (d *FabricXDeployer) markNetworkVerified(ctx context.Context, networkID int64) error {
+	if err := d.db.UpdateNetworkStatus(ctx, &db.UpdateNetworkStatusParams{
+		ID:     networkID,
+		Status: "running",
+	}); err != nil {
+		return fmt.Errorf("mark network %d running: %w", networkID, err)
+	}
+	return nil
 }
 
 // GetStatus returns the deployment status of a Fabric X network

--- a/pkg/nodes/fabricx/committer.go
+++ b/pkg/nodes/fabricx/committer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -67,9 +68,30 @@ func (c *Committer) prefix() string {
 	return containerNamePrefix(c.mspID, c.opts.Name)
 }
 
-// Init generates certificates, writes configs, returns deployment config
+// Init generates certificates, writes configs, returns deployment config.
+//
+// Init is idempotent: if the committer's row already has a complete
+// deployment config (sign cert + TLS cert + key IDs), Init reuses that
+// config rather than minting new keys. This prevents the "certificate
+// mismatch" panic that occurs when a re-run of Init regenerates the
+// committer's identity after the network's genesis block already embeds
+// the original cert. Cert rotation must go through RenewCertificates,
+// which preserves the public-key identity that's locked into genesis.
 func (c *Committer) Init() (*nodetypes.FabricXCommitterDeploymentConfig, error) {
 	ctx := context.Background()
+
+	if existing, ok := c.loadExistingDeployment(ctx); ok {
+		c.logger.Info("Reusing existing FabricX committer deployment config (skipping cert regen)",
+			"name", c.opts.Name,
+			"signKeyId", existing.SignKeyID,
+			"tlsKeyId", existing.TLSKeyID,
+			"tlsCertFingerprint", CertFingerprint([]byte(existing.TLSCert)),
+		)
+		if err := c.ensureMaterials(existing); err != nil {
+			return nil, fmt.Errorf("ensure materials for reused committer: %w", err)
+		}
+		return existing, nil
+	}
 
 	org, err := c.orgService.GetOrganization(ctx, c.organizationID)
 	if err != nil {
@@ -389,6 +411,39 @@ func (c *Committer) Init() (*nodetypes.FabricXCommitterDeploymentConfig, error) 
 // TLS-only orderers reject with "error reading server preface: EOF". The
 // upstream sidecar does not yet load root CAs from the genesis block itself
 // (sidecar/config.go still has a "TODO: Fetch Root CAs."), so we do it here.
+// loadExistingDeployment returns the persisted deployment config for this
+// committer if one exists, alongside ok=true. Used by Init() to short-circuit
+// cert regeneration. A "complete" config has both key IDs and both
+// certificate PEMs populated; partial configs are rejected so the caller
+// rebuilds them from scratch.
+func (c *Committer) loadExistingDeployment(ctx context.Context) (*nodetypes.FabricXCommitterDeploymentConfig, bool) {
+	if c.db == nil || c.nodeID <= 0 {
+		return nil, false
+	}
+	node, err := c.db.GetNode(ctx, c.nodeID)
+	if err != nil || !node.DeploymentConfig.Valid {
+		return nil, false
+	}
+	return decodeCommitterDeployment(node.DeploymentConfig.String)
+}
+
+func decodeCommitterDeployment(raw string) (*nodetypes.FabricXCommitterDeploymentConfig, bool) {
+	var cfg nodetypes.FabricXCommitterDeploymentConfig
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return nil, false
+	}
+	if cfg.Type != "fabricx-committer" {
+		return nil, false
+	}
+	if cfg.SignKeyID == 0 || cfg.TLSKeyID == 0 {
+		return nil, false
+	}
+	if cfg.SignCert == "" || cfg.TLSCert == "" {
+		return nil, false
+	}
+	return &cfg, true
+}
+
 func (c *Committer) SetGenesisBlock(genesisBlock []byte) error {
 	dir := filepath.Join(c.baseDir(), "sidecar", "genesis")
 	if err := os.MkdirAll(dir, 0755); err != nil {

--- a/pkg/nodes/fabricx/common.go
+++ b/pkg/nodes/fabricx/common.go
@@ -64,6 +64,21 @@ const (
 // Empty or all-junk input falls back to "node" so the caller still
 // gets a usable, predictable directory name instead of an empty string
 // (which would resolve baseDir to the parent and overwrite siblings).
+// Slugify is the exported wrapper around slugify. It exists so callers
+// outside the fabricx package (e.g. the network deployer) can compute the
+// same on-disk paths Init() uses when it lays out an orderer group's
+// directories.
+func Slugify(name string) string { return slugify(name) }
+
+// OrdererRoleTLSCertPath returns the absolute path of the on-disk TLS
+// certificate for a given orderer group role under the data directory.
+// The role argument should match a directory written by Init() (one of
+// "router", "batcher", "consenter", "assembler"). The path is computed
+// from dataPath and groupName the same way Init() lays out the group.
+func OrdererRoleTLSCertPath(dataPath, groupName, role string) string {
+	return filepath.Join(dataPath, "fabricx-orderers", slugify(groupName), role, "tls", "server.crt")
+}
+
 func slugify(name string) string {
 	lower := strings.ToLower(name)
 	var b strings.Builder

--- a/pkg/nodes/fabricx/orderergroup.go
+++ b/pkg/nodes/fabricx/orderergroup.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -20,6 +22,15 @@ import (
 	"github.com/chainlaunch/chainlaunch/pkg/logger"
 	nodetypes "github.com/chainlaunch/chainlaunch/pkg/nodes/types"
 )
+
+// ErrTLSCertImmutableAfterGenesis is returned when an attempt is made to
+// regenerate a FabricX orderer-group TLS certificate after the certificate
+// has already been embedded in a network's genesis block. The genesis block
+// is immutable, so re-issuing the cert would cause a "certificate mismatch"
+// panic at router startup. To rotate the cert, use RenewCertificates with
+// the same key pair (which preserves the existing cert in the genesis path)
+// or recreate the network from scratch.
+var ErrTLSCertImmutableAfterGenesis = errors.New("fabricx: orderer TLS cert is locked into genesis and cannot be regenerated; use RenewCertificates or recreate the network")
 
 // OrdererGroup manages the 4 sub-containers of a Fabric X orderer group:
 // router, batcher, consenter, assembler
@@ -66,9 +77,42 @@ func (og *OrdererGroup) prefix() string {
 	return containerNamePrefix(og.mspID, og.opts.Name)
 }
 
-// Init generates certificates, writes config files, and returns the deployment config
+// Init generates certificates, writes config files, and returns the deployment config.
+//
+// Init is idempotent: if the orderer group's row already has a complete
+// deployment config (sign cert + TLS cert + key IDs), Init reuses that
+// existing config rather than regenerating new keys. This is the critical
+// invariant that prevents the "certificate mismatch" panic — once a TLS
+// cert has been embedded in a network's genesis block, regenerating that
+// cert (with possibly different SANs) will cause the orderer router to
+// crash at startup. If the caller really needs a fresh cert, they must
+// either rotate via RenewCertificates (which preserves the public-key
+// identity) or recreate the network.
 func (og *OrdererGroup) Init() (*nodetypes.FabricXOrdererGroupDeploymentConfig, error) {
 	ctx := context.Background()
+
+	// Idempotency guard: if this orderer group already has a complete
+	// deployment config persisted, reuse it instead of minting a new key
+	// pair. We look up by node-group id (preferred, ADR-0001 path) or by
+	// the parent node row id. A "complete" config is one that has both
+	// sign-key + TLS-key IDs and both certificates — anything less and
+	// we treat it as a half-finished init that must restart.
+	if existing, ok := og.loadExistingDeployment(ctx); ok {
+		og.logger.Info("Reusing existing FabricX orderer-group deployment config (skipping cert regen)",
+			"name", og.opts.Name,
+			"signKeyId", existing.SignKeyID,
+			"tlsKeyId", existing.TLSKeyID,
+			"tlsCertFingerprint", CertFingerprint([]byte(existing.TLSCert)),
+		)
+		// Make sure on-disk MSP/TLS dirs reflect what's in the DB. If
+		// disk was wiped between runs ensureMaterials will recreate
+		// them from the persisted keys; if disk and DB already agree
+		// it's a no-op.
+		if err := og.ensureMaterials(existing); err != nil {
+			return nil, fmt.Errorf("ensure materials for reused orderer group: %w", err)
+		}
+		return existing, nil
+	}
 
 	// Get organization
 	org, err := og.orgService.GetOrganization(ctx, og.organizationID)
@@ -341,6 +385,47 @@ func (og *OrdererGroup) Init() (*nodetypes.FabricXOrdererGroupDeploymentConfig, 
 	)
 
 	return cfg, nil
+}
+
+// loadExistingDeployment returns the persisted deployment config for this
+// orderer group if one exists, alongside ok=true. It is used by Init() to
+// short-circuit cert regeneration once the group has been initialized.
+//
+// The lookup reads the node row via og.nodeID. A returned config must have
+// both key IDs and both certificate PEMs populated to count as "complete"
+// — anything less is treated as a partial init that should redo the work
+// from scratch.
+func (og *OrdererGroup) loadExistingDeployment(ctx context.Context) (*nodetypes.FabricXOrdererGroupDeploymentConfig, bool) {
+	if og.db == nil || og.nodeID <= 0 {
+		return nil, false
+	}
+	node, err := og.db.GetNode(ctx, og.nodeID)
+	if err != nil || !node.DeploymentConfig.Valid {
+		return nil, false
+	}
+	return decodeOrdererDeployment(node.DeploymentConfig.String)
+}
+
+// decodeOrdererDeployment parses a deployment_config JSON blob into an
+// orderer-group deployment config and returns ok=true only if the result
+// is "complete" — both key IDs set and both certificate PEMs present.
+// Partial configs (e.g. a half-finished init) are rejected so the caller
+// rebuilds them from scratch.
+func decodeOrdererDeployment(raw string) (*nodetypes.FabricXOrdererGroupDeploymentConfig, bool) {
+	var cfg nodetypes.FabricXOrdererGroupDeploymentConfig
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return nil, false
+	}
+	if cfg.Type != "fabricx-orderer-group" {
+		return nil, false
+	}
+	if cfg.SignKeyID == 0 || cfg.TLSKeyID == 0 {
+		return nil, false
+	}
+	if cfg.SignCert == "" || cfg.TLSCert == "" {
+		return nil, false
+	}
+	return &cfg, true
 }
 
 // SetGenesisBlock writes the genesis block to the orderer group's genesis directories

--- a/pkg/nodes/service/fabric.go
+++ b/pkg/nodes/service/fabric.go
@@ -582,10 +582,15 @@ func (s *NodeService) UpdateFabricPeer(ctx context.Context, opts UpdateFabricPee
 		deployPeerConfig.Mode = opts.Mode
 	}
 
-	// Update configuration fields if provided
+	// Track which fields changed so we know whether to refresh nodes.endpoint
+	// and re-register with monitoring. SynchronizePeerConfig already bounces
+	// the running peer so it picks up address-bearing changes from core.yaml.
+	endpointChanged := false
+
 	if opts.ExternalEndpoint != "" && opts.ExternalEndpoint != peerConfig.ExternalEndpoint {
 		peerConfig.ExternalEndpoint = opts.ExternalEndpoint
 		deployPeerConfig.ExternalEndpoint = opts.ExternalEndpoint
+		endpointChanged = true
 	}
 	if opts.ListenAddress != "" && opts.ListenAddress != peerConfig.ListenAddress {
 		if err := s.validateAddressFormat(opts.ListenAddress); err != nil {
@@ -695,6 +700,36 @@ func (s *NodeService) UpdateFabricPeer(ctx context.Context, opts UpdateFabricPee
 		}
 	}
 
+	// When the externally-advertised endpoint changes, refresh the
+	// nodes.endpoint column (used by list views and consenter dropdowns) and
+	// re-register with monitoring so health checks dial the new address.
+	if endpointChanged {
+		updated, err := s.db.UpdateNodeEndpoint(ctx, &db.UpdateNodeEndpointParams{
+			ID: opts.NodeID,
+			Endpoint: sql.NullString{
+				String: peerConfig.ExternalEndpoint,
+				Valid:  true,
+			},
+		})
+		if err != nil {
+			s.logger.Warn("failed to update nodes.endpoint", "nodeID", opts.NodeID, "endpoint", peerConfig.ExternalEndpoint, "error", err)
+		} else {
+			node = updated
+		}
+		if s.monitoringService != nil {
+			if err := s.monitoringService.AddNodeToMonitor(
+				node.ID,
+				node.Name,
+				peerConfig.ExternalEndpoint,
+				string(types.PlatformFabric),
+				string(types.NodeTypeFabricPeer),
+				nil,
+			); err != nil {
+				s.logger.Warn("failed to refresh monitoring with new endpoint", "nodeID", opts.NodeID, "error", err)
+			}
+		}
+	}
+
 	// Return updated node response
 	_, nodeResponse := s.mapDBNodeToServiceNode(node)
 	return nodeResponse, nil
@@ -750,10 +785,19 @@ func (s *NodeService) UpdateFabricOrderer(ctx context.Context, opts UpdateFabric
 		deployOrdererConfig.Mode = opts.Mode
 	}
 
-	// Update configuration fields if provided
+	// Track which fields changed so we can refresh nodes.endpoint, monitoring,
+	// and bounce the running orderer when address-bearing fields move. Mode
+	// changes already restart below; this catches IP/port edits that
+	// orderer.yaml renders, where the running container otherwise keeps the
+	// old binding until something else triggers a restart.
+	endpointChanged := false
+	addressesChanged := false
+
 	if opts.ExternalEndpoint != "" && opts.ExternalEndpoint != ordererConfig.ExternalEndpoint {
 		ordererConfig.ExternalEndpoint = opts.ExternalEndpoint
 		deployOrdererConfig.ExternalEndpoint = opts.ExternalEndpoint
+		endpointChanged = true
+		addressesChanged = true
 	}
 	if opts.ListenAddress != "" && opts.ListenAddress != ordererConfig.ListenAddress {
 		if err := s.validateAddressFormat(opts.ListenAddress); err != nil {
@@ -761,6 +805,7 @@ func (s *NodeService) UpdateFabricOrderer(ctx context.Context, opts UpdateFabric
 		}
 		ordererConfig.ListenAddress = opts.ListenAddress
 		deployOrdererConfig.ListenAddress = opts.ListenAddress
+		addressesChanged = true
 	}
 	if opts.AdminAddress != "" && opts.AdminAddress != ordererConfig.AdminAddress {
 		if err := s.validateAddressFormat(opts.AdminAddress); err != nil {
@@ -768,6 +813,7 @@ func (s *NodeService) UpdateFabricOrderer(ctx context.Context, opts UpdateFabric
 		}
 		ordererConfig.AdminAddress = opts.AdminAddress
 		deployOrdererConfig.AdminAddress = opts.AdminAddress
+		addressesChanged = true
 	}
 	if opts.OperationsListenAddress != "" && opts.OperationsListenAddress != ordererConfig.OperationsListenAddress {
 		if err := s.validateAddressFormat(opts.OperationsListenAddress); err != nil {
@@ -775,6 +821,7 @@ func (s *NodeService) UpdateFabricOrderer(ctx context.Context, opts UpdateFabric
 		}
 		ordererConfig.OperationsListenAddress = opts.OperationsListenAddress
 		deployOrdererConfig.OperationsListenAddress = opts.OperationsListenAddress
+		addressesChanged = true
 	}
 	if opts.DomainNames != nil {
 		ordererConfig.DomainNames = opts.DomainNames
@@ -838,6 +885,48 @@ func (s *NodeService) UpdateFabricOrderer(ctx context.Context, opts UpdateFabric
 
 		if err := s.startFabricOrderer(ctx, node); err != nil {
 			return nil, fmt.Errorf("failed to start orderer with new mode: %w", err)
+		}
+	}
+
+	// If addresses changed but mode didn't, the running orderer is still
+	// bound to the old IP/port — bounce it so writeConfigFiles regenerates
+	// orderer.yaml and the listener picks up the new binding. Skipped when
+	// the orderer isn't running or when we already restarted via modeChanged.
+	if addressesChanged && !modeChanged && types.NodeStatus(node.Status) == types.NodeStatusRunning {
+		if err := s.stopFabricOrderer(ctx, node); err != nil {
+			s.logger.Warn("failed to stop orderer before regenerating config", "nodeID", opts.NodeID, "error", err)
+		}
+		if err := s.startFabricOrderer(ctx, node); err != nil {
+			return nil, fmt.Errorf("failed to restart orderer after address change: %w", err)
+		}
+	}
+
+	// Refresh nodes.endpoint and the monitoring registration so views and
+	// health checks see the new public address.
+	if endpointChanged {
+		updated, err := s.db.UpdateNodeEndpoint(ctx, &db.UpdateNodeEndpointParams{
+			ID: opts.NodeID,
+			Endpoint: sql.NullString{
+				String: ordererConfig.ExternalEndpoint,
+				Valid:  true,
+			},
+		})
+		if err != nil {
+			s.logger.Warn("failed to update nodes.endpoint", "nodeID", opts.NodeID, "endpoint", ordererConfig.ExternalEndpoint, "error", err)
+		} else {
+			node = updated
+		}
+		if s.monitoringService != nil {
+			if err := s.monitoringService.AddNodeToMonitor(
+				node.ID,
+				node.Name,
+				ordererConfig.ExternalEndpoint,
+				string(types.PlatformFabric),
+				string(types.NodeTypeFabricOrderer),
+				nil,
+			); err != nil {
+				s.logger.Warn("failed to refresh monitoring with new endpoint", "nodeID", opts.NodeID, "error", err)
+			}
 		}
 	}
 

--- a/web/src/components/nodes/fabric-node-form.tsx
+++ b/web/src/components/nodes/fabric-node-form.tsx
@@ -366,13 +366,16 @@ export function FabricNodeForm({
 											className="min-h-[100px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 											placeholder="example.com&#10;192.168.1.1"
 											onChange={(e) => {
-												const domains = e.target.value
-													.split('\n')
+												field.onChange(e.target.value.split('\n'))
+											}}
+											onBlur={() => {
+												const cleaned = (field.value ?? [])
 													.map((d) => d.trim())
 													.filter(Boolean)
-												field.onChange(domains)
+												field.onChange(cleaned)
+												field.onBlur()
 											}}
-											value={field.value?.join('\n') || ''}
+											value={field.value?.join('\n') ?? ''}
 										/>
 									</FormControl>
 									<FormMessage />


### PR DESCRIPTION
## Summary

Editing a Fabric peer or orderer's `externalEndpoint` only updated `node_config`. Three things stayed stale:

1. `nodes.endpoint` (used by node lists, BFT consenter dropdown, monitoring lookups)
2. The monitoring registration (kept dialing the old address for health checks)
3. The running orderer container (kept its old IP/port binding because nothing called Stop+Start outside the mode-change path)

## Changes

- Track `endpointChanged` / `addressesChanged` in `UpdateFabricPeer` and `UpdateFabricOrderer`
- Update `nodes.endpoint` via `UpdateNodeEndpoint` and re-register with the monitoring service when the external endpoint changes
- Stop+start the orderer on address-bearing changes (peer side already bounces via `SynchronizePeerConfig`)

Also bundled in this branch (already on local main, never pushed):
- `f162776` feat(fabricx): idempotent cert init + post-provisioning verification
- `fc1d368` fix(web): trim fabric domain inputs on blur, not on every keystroke

## Test plan

- [ ] Edit a peer's external endpoint via the UI; verify the new value appears in node lists and the BFT consenter dropdown immediately
- [ ] Edit an orderer's external endpoint while running; verify it picks up the new binding (orderer.yaml regen + restart)
- [ ] Confirm monitoring health checks dial the new address (no stale-IP failures)
- [ ] Verify mode change path still works (existing behavior, no regression)